### PR TITLE
Change minimum connection interval

### DIFF
--- a/100_Projects_in_100_Days/Day019_Connection_Parameters/Connection_Parameters/Connection_Parameters.cydsn/main.c
+++ b/100_Projects_in_100_Days/Day019_Connection_Parameters/Connection_Parameters/Connection_Parameters.cydsn/main.c
@@ -50,7 +50,7 @@
 *****************************************************************************/
 CYBLE_GAP_CONN_UPDATE_PARAM_T connectionParameters = 
 {
-    400,                /* Minimum connection interval - 400 x 1.25 = 500 ms */
+     16,                /* Minimum connection interval -  16 x 1.25 =  20 ms */
     400,                /* Maximum connection interval - 400 x 1.25 = 500 ms */
     1,                  /* Slave latency - 1 */
     500                 /* Supervision timeout - 500 x 10 = 5000 ms */


### PR DESCRIPTION
iOS devices require intervalMin + 20ms >= intervalMax, so updates will be rejected if intervalMin == intervalMax
