### PR TITLE
accommodating the 256KB PSoC4 in lab29

### DIFF
--- a/100_Projects_in_100_Days/Day029_BLE_SFlash_Write/User_SFlash_Write/User_SFlash_Write.cydsn/WriteUserSFlash.c
+++ b/100_Projects_in_100_Days/Day029_BLE_SFlash_Write/User_SFlash_Write/User_SFlash_Write.cydsn/WriteUserSFlash.c
@@ -75,7 +75,7 @@ uint32 WriteUserSFlashRow(uint8 userRowNUmber, uint32 *dataPointer)
 	/****** Initialize SRAM parameters for the LOAD FLASH command ******/
 	/* byte 3,2 and 1 are null */
 	/* byte 0 (i.e. 7F) is the number of bytes to be written */
-	cmdDataBuffer[1]=0x0000007F;	 
+	cmdDataBuffer[1]=(uint32)(USER_SFLASH_ROW_SIZE-1);	 
     
 	/* Initialize the SRAM buffer with data bytes */
     for(localCount = 0; localCount < (CY_FLASH_SIZEOF_ROW/4); localCount++)    

--- a/100_Projects_in_100_Days/Day029_BLE_SFlash_Write/User_SFlash_Write/User_SFlash_Write.cydsn/WriteUserSFlash.h
+++ b/100_Projects_in_100_Days/Day029_BLE_SFlash_Write/User_SFlash_Write/User_SFlash_Write.cydsn/WriteUserSFlash.h
@@ -32,13 +32,15 @@
 *                  Enums and macros
 *****************************************************/  
 #define SWITCH_PRESSED                  (0u)   /* Active low user switch on BLE Pioneer kit */ 
-#define USER_SFLASH_ROW_SIZE            (128u) /* SFlash row size for 128KB flash BLE device. For other PSoC 4 BLE devices 
+#define USER_SFLASH_ROW_SIZE            (128u) /* SFlash row size for 128KB flash BLE device. For 256KB flash BLE device, 
+                                                * use (256u) for the row size. For other PSoC 4 BLE devices 
                                                 * with higher flash size, this example project might need some modification.
                                                 * Please check the device datasheet and TRM before using this code on non 128KB
                                                 * flash devices */
 #define SFLASH_STARTING_VALUE           (0x00) /* Starting value to be stored in user SFlash to demonstrate SFlash write API */
 #define USER_SFLASH_ROWS                (4u)   /* Total number of user SFlash rows supported by the device */
 #define USER_SFLASH_BASE_ADDRESS        (0x0FFFF200u) /* Starting address of user SFlash row for 128KB PSoC 4 BLE device */    
+                                               /* for 256KB PSoC4 device use 0x0FFFF400u base address */ 
     
 #define LOAD_FLASH				         0x80000004
 #define WRITE_USER_SFLASH_ROW	         0x80000018


### PR DESCRIPTION
I've located the differences between the 128KB and 256KB PSoC4 devices as they pertain to this lab. Namely, the base address is slightly different and the flash row size in 256KB devices is twice as long.